### PR TITLE
Correct broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![Build Status](https://travis-ci.org/lacion/cookiecutter-golang.svg?branch=master)](https://travis-ci.org/lacion/cookiecutter-golang)
 
-Powered by [Cookiecutter](https://github.com/audreyr/cookiecutter), Cookiecutter Golang is a framework for jumpstarting production-ready go projects quickly.
+Powered by [Cookiecutter](https://github.com/audreyr/cookiecutter) - Cookiecutter Golang is a framework for jump-starting production-ready Go projects quickly.
 
 ## Features
 
 - Generous `Makefile` with management commands
-- Uses `go dep` (with optional go module support _requires go 1.11_)
+- Uses `go dep` (with optional [Go Modules](https://golang.org/ref/mod) support _requires go 1.11_)
 - injects build time and git hash at build time.
 
 ## Optional Integrations
@@ -16,21 +16,21 @@ Powered by [Cookiecutter](https://github.com/audreyr/cookiecutter), Cookiecutter
 - Can use [cobra](https://github.com/spf13/cobra) for cli tools
 - Can use [logrus](https://github.com/sirupsen/logrus) for logging
 - Can create dockerfile for building go binary and dockerfile for final go binary (no code in final container)
-- If docker is used adds docker management commands to makefile
+- If Docker is used adds Docker management commands to makefile
 - Option of TravisCI, CircleCI or None
 
 ## Constraints
 
-- Uses `dep` or `mod` for dependency management
+- Uses `dep` or `mod` for dependency management.
 - Only maintained 3rd party libraries are used.
 
-This project now uses docker multistage builds, you need at least docker version v17.05.0-ce to use the docker file in this template, [you can read more about multistage builds here](https://www.critiqus.com/post/multi-stage-docker-builds/).
+This project now uses Docker multistage builds, you need at least Docker version v17.05.0-ce to use the Docker file in this template, [you can read more about multistage builds here](https://www.critiqus.com/post/multi-stage-docker-builds/).
 
 ## Docker
 
-This template uses docker [multistage]](https://www.critiqus.com/post/multi-stage-docker-builds/) builds to make images slimmer and containers only the final project binary and assets with no source code whatsoever.
+This template uses Docker [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build) builds to make images slimmer and containers only the final project binary and assets with no source code whatsoever.
 
-Apps run under non root user and also with [dumb-init](https://github.com/Yelp/dumb-init)
+Apps run as non-root using [dumb-init](https://github.com/Yelp/dumb-init).
 
 Run `make help` to see the available management commands, or just run `make build` to build your project.
 
@@ -40,6 +40,6 @@ $ make build
 $ ./bin/echoserver
 ```
 
-## Projects build with cookiecutter-golang
+## Projects built with cookiecutter-golang
 
-- [iothub](https://github.com/lacion/iothub) websocket multiroom server for IoT
+- [iothub](https://github.com/lacion/iothub) - multiroom websocket server for IoT


### PR DESCRIPTION
 - Replace non-functional link to Docker multi-stage builds post with official Docker doc link.
 - Apply minor copy improvements.

Broken URL: https://www.critiqus.com/post/multi-stage-docker-builds/
![Screenshot from 2021-02-06 11-50-20](https://user-images.githubusercontent.com/1451007/107127769-a1350180-6875-11eb-9fa1-dca79121f290.png)
